### PR TITLE
Add support for jemalloc

### DIFF
--- a/src/acconfig.h
+++ b/src/acconfig.h
@@ -550,19 +550,18 @@
 #define PIKE_OOB_WORKS -1
 
 /* dlmalloc has mallinfo. */
-#if defined(USE_DL_MALLOC) && !defined(HAVE_MALLINFO)
-#define HAVE_MALLINFO
+#if !defined(USE_JEMALLOC)
+#    if defined(USE_DL_MALLOC) && !defined(HAVE_MALLINFO)
+#        define HAVE_MALLINFO
 
-#if defined (HAVE_MALLOC_H) && defined (HAVE_STRUCT_MALLINFO)
-#include <malloc.h>
-#else /* HAVE_MALLOC_H && HAVE_STRUCT_MALLINFO */
-
-#ifndef MALLINFO_FIELD_TYPE
-#define MALLINFO_FIELD_TYPE size_t
-#endif  /* MALLINFO_FIELD_TYPE */
+#        if defined (HAVE_MALLOC_H) && defined (HAVE_STRUCT_MALLINFO)
+#            include <malloc.h>
+#        elif !defined(MALLINFO_FIELD_TYPE)
+#            define MALLINFO_FIELD_TYPE size_t
+#        endif  /* defined (HAVE_MALLOC_H) && defined (HAVE_STRUCT_MALLINFO) */
 
 /* Needed for size_t. */
-#include <stddef.h>
+#        include <stddef.h>
 
 /* dlmalloc definition of struct mallinfo. */
 struct mallinfo {
@@ -578,8 +577,8 @@ struct mallinfo {
   MALLINFO_FIELD_TYPE keepcost; /* releasable (via malloc_trim) space */
 };
 
-#endif /* HAVE_USR_INCLUDE_MALLOC_H */
+#    endif /* defined(USE_DL_MALLOC) && !defined(HAVE_MALLINFO) */
 
-#endif
+#endif /* !defined(USE_JEMALLOC) */
 
 #endif /* MACHINE_H */

--- a/src/builtin.cmod
+++ b/src/builtin.cmod
@@ -5962,15 +5962,15 @@ static void get_val_module(void)
 /* Always do the lookup in the Val module dynamically to allow the
  * values to be replaced. */
 #define GET_VAL(NAME)							\
-  PMOD_EXPORT struct object *PIKE_CONCAT (get_val_, NAME) (void)	\
+  PMOD_EXPORT struct object *get_val_ ## NAME (void)			\
   {									\
     struct svalue index, res;						\
     if (!val_module) get_val_module();					\
     SET_SVAL(index, T_STRING, 0, string, NULL);				\
-    MAKE_CONST_STRING (index.u.string, TOSTR (NAME));			\
+    MAKE_CONST_STRING (index.u.string, #NAME);				\
     object_index_no_free (&res, val_module, 0, &index);			\
     if (TYPEOF(res) != T_OBJECT)					\
-      Pike_error ("\"Val." TOSTR (NAME) "\" didn't resolve to an object.\n"); \
+      Pike_error ("\"Val." #NAME "\" didn't resolve to an object.\n");	\
     return res.u.object;						\
   }
 

--- a/src/configure.in
+++ b/src/configure.in
@@ -1026,6 +1026,16 @@ else
   enable_dlmalloc=no
 fi
 
+AC_ARG_ENABLE(jemalloc, MY_DESCR([--enable-jemalloc],
+				 [use jemalloc implementation instead of system malloc]),
+	      [enable_jemalloc=yes], [enable_jemalloc=no])
+if test "x$enable_jemalloc" = xyes; then
+  AC_DEFINE(USE_JEMALLOC, [1], [Set to 1 if jemalloc should be used for memory allocation])
+  LIBS="-ljemalloc ${LIBS}"
+else
+  enable_jemalloc=no
+fi
+
 MY_AC_ARG_WITH(cleanup-on-exit,
 	       MY_DESCR([--with-cleanup-on-exit],
 			[Do full cleanup at exit to detect leaks better.]),
@@ -2818,7 +2828,8 @@ AC_CHECK_HEADERS(winsock2.h sys/rusage.h sys/time.h \
 		 sys/id.h mach-o/dyld.h sys/ptrace.h \
 		 thread.h dlfcn.h dld.h dl.h sys/times.h sched.h \
 		 sys/procfs.h sys/socket.h sys/uio.h fcntl.h \
-		 malloc.h netinet/in.h sys/wait.h windows.h grp.h pwd.h \
+		 malloc.h jemalloc/jemalloc.h netinet/in.h sys/wait.h \
+		 windows.h grp.h pwd.h \
 		 passwd.h group.h winsock.h sys/file.h poll.h \
 		 sys/poll.h socket.h ieeefp.h fp_class.h floatingpoint.h \
 		 sys/priocntl.h sys/sched.h winbase.h \
@@ -4396,7 +4407,7 @@ AC_MSG_RESULT($pike_cv_has_struct_sockaddr_in6)
 
 #############################################################################
 
-if test $ac_cv_header_malloc_h = yes; then
+if test $ac_cv_header_malloc_h = yes && test "x$enable_jemalloc" = xno; then
   AC_MSG_CHECKING(struct mallinfo in malloc.h)
   AC_CACHE_VAL(pike_cv_struct_mallinfo, [
     AC_TRY_LINK([
@@ -7826,6 +7837,7 @@ PAD_FEATURE([cdebug])$with_cdebug
 PAD_FEATURE([rtldebug])$with_rtldebug
 PAD_FEATURE([dmalloc])$with_dmalloc
 PAD_FEATURE([dlmalloc])$enable_dlmalloc
+PAD_FEATURE([jemalloc])$enable_jemalloc
 PAD_FEATURE([byte code format])$byte_code_format
 PAD_FEATURE([module reloc])${with_relocatable_dumped_modules:-no}
 PAD_FEATURE([use machine code])$with_machine_code

--- a/src/global.h
+++ b/src/global.h
@@ -325,12 +325,14 @@ void *alloca();
 #include <limits.h>
 #include <float.h>
 
-#ifdef HAVE_MALLOC_H
+#if defined(USE_JEMALLOC)
+#include <jemalloc/jemalloc.h>
+#elif defined(HAVE_MALLOC_H)
 #if !defined(__FreeBSD__) && !defined(__OpenBSD__)
 /* FreeBSD and OpenBSD has <malloc.h>, but it just contains a warning... */
 #include <malloc.h>
 #endif /* !__FreeBSD__ && !__OpenBSD */
-#endif
+#endif /* if defined(USE_JEMALLOC) */
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/modules/HTTPLoop/requestobject.c
+++ b/src/modules/HTTPLoop/requestobject.c
@@ -654,8 +654,8 @@ static void actually_send(struct send_args *a)
 #if defined(TCP_CORK) && defined(SOL_TCP)
     DWERROR("cork... \n");
     {
-      int true=1;
-      fd_setsockopt( a->to->fd, SOL_TCP, TCP_CORK, &true, sizeof(true) );
+      int true_val=1;
+      fd_setsockopt( a->to->fd, SOL_TCP, TCP_CORK, &true_val, sizeof(true_val) );
     }
 #endif
     fail = WRITE(a->to->fd, (char *)data, data_len);
@@ -745,8 +745,8 @@ static void actually_send(struct send_args *a)
   DWERROR("all written.. \n");
 #if defined(TCP_CORK) && defined(SOL_TCP)
   {
-    int false = 0;
-    fd_setsockopt( a->to->fd, SOL_TCP, TCP_CORK, &false, sizeof(false) );
+    int false_val = 0;
+    fd_setsockopt( a->to->fd, SOL_TCP, TCP_CORK, &false_val, sizeof(false_val) );
   }
 #endif
   {


### PR DESCRIPTION
jemalloc handles threaded allocations better than the default glibc's ptmalloc2, but it's less relevant for Pike.  Smaller memory fragmentation is more tangible.

You need jemalloc library available on your OS to be able to compile Pike with jemalloc.  Build it with  `make CONFIGUREARGS="--enable-jemalloc"`.

The only externally visible change is in `_memory_usage()` function which depends on malloc's implementation-specific details.  glibc's malloc provides `struct mallinfo mallinfo()`, while jemalloc provides `int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);` where `name` argument starts with `"stats."` (see `man jemalloc`).
 

