### PR TITLE
Enable string import of single files. Throw error on failed import.

### DIFF
--- a/lib/master.pike.in
+++ b/lib/master.pike.in
@@ -2934,19 +2934,28 @@ joinnode handle_import(string path, string|void current_file,
   module_node node = module_node_cache[current_handler][path] =
     module_node("import::"+path, 0, current_handler);
 #endif /* 0 */
-  joinnode node = joinnode(({}), current_handler);
+  auto path_stat = file_stat(path);
+  if (!path_stat)
+    compile_cb_error("Failed to stat file: %O\n", path);
+  joinnode node;
+  if (path_stat->isreg) {
+    node = low_cast_to_object(path, current_file, current_handler);
+  }
+  if (path_stat->isdir) {
+    node = joinnode(({}), current_handler);
 #ifdef PIKE_MODULE_RELOC
-  // If we have PIKE_MODULE_RELOC enabled,
-  // we might need to map to multiple directories.
-  if(path == "/${PIKE_MODULE_PATH}" ||
-     has_prefix(path, "/${PIKE_MODULE_PATH}/")) {
-    string tmp = path[21..];
-    foreach(pike_module_path, string prefix) {
-      node->add_path(sizeof(tmp)? combine_path(prefix, tmp) : prefix);
-    }
-  } else
+    // If we have PIKE_MODULE_RELOC enabled,
+    // we might need to map to multiple directories.
+    if(path == "/${PIKE_MODULE_PATH}" ||
+       has_prefix(path, "/${PIKE_MODULE_PATH}/")) {
+      string tmp = path[21..];
+      foreach(pike_module_path, string prefix) {
+        node->add_path(sizeof(tmp)? combine_path(prefix, tmp) : prefix);
+      }
+    } else
 #endif /* PIKE_MODULE_RELOC */
-    node->add_path(path);
+      node->add_path(path);
+  }
   return node;
 }
 

--- a/lib/master.pike.in
+++ b/lib/master.pike.in
@@ -2941,7 +2941,7 @@ joinnode handle_import(string path, string|void current_file,
   if (path_stat->isreg) {
     node = low_cast_to_object(path, current_file, current_handler);
   }
-  if (path_stat->isdir) {
+  else if (path_stat->isdir) {
     node = joinnode(({}), current_handler);
 #ifdef PIKE_MODULE_RELOC
     // If we have PIKE_MODULE_RELOC enabled,
@@ -3605,7 +3605,7 @@ string _master_file_name;
 // Gets set to 1 if we're in async-mode (script->main() returned <0)
 private int(0..1) _async=0;
 
-//! Returns 1 if we´re in async-mode, e.g. if the main method has
+//! Returns 1 if weÂ´re in async-mode, e.g. if the main method has
 //! returned a negative number.
 int(0..1) asyncp() {
   return _async;
@@ -3827,7 +3827,7 @@ void _main(array(string(0..255)) orig_argv)
         exit(0);
 
       case "version":
-        exit(0, string_to_utf8(version() + " Copyright © 1994-2018 Linköping University\n"
+        exit(0, string_to_utf8(version() + " Copyright Â© 1994-2018 LinkÃ¶ping University\n"
             "Pike comes with ABSOLUTELY NO WARRANTY; This is free software and you are\n"
             "welcome to redistribute it under certain conditions; read the files\n"
             "COPYING and COPYRIGHT in the Pike distribution for more details.\n"));


### PR DESCRIPTION
Previously, string-style import would only work with pmod
directories. Now it also works with single-file pmods.
Additionally, the interpreter would be silent about invalid pathes.
Now it throws an error if it fails to stat a path.