### PR TITLE
Re-enable SIGUSR1 and SIGUSR2.

### DIFF
--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -480,16 +480,12 @@ static const struct sigdesc signal_desc []={
 #ifdef SIGTERM
   { SIGTERM, "SIGTERM" },
 #endif
-
-#if !defined(__linux__) || !defined(_REENTRANT)
 #ifdef SIGUSR1
   { SIGUSR1, "SIGUSR1" },
 #endif
 #ifdef SIGUSR2
   { SIGUSR2, "SIGUSR2" },
 #endif
-#endif /* !defined(__linux__) || !defined(_REENTRANT) */
-
 #ifdef SIGCHLD
   { SIGCHLD, "SIGCHLD" },
 #endif
@@ -937,10 +933,6 @@ static void f_signal(int args)
   signum=Pike_sp[-args].u.integer;
   if(signum <0 ||
      signum >=MAX_SIGNALS
-#if defined(__linux__) && defined(_REENTRANT)
-     || signum == SIGUSR1
-     || signum == SIGUSR2
-#endif
     )
   {
     Pike_error("Signal %d out of range.\n", signum);


### PR DESCRIPTION
These signals were disabled because LinuxThreads used them
internally, but since 2.6-ish kernel version the pthreads
implementation was superseded by NPTL. It is high time to return
SIGUSR1 and SIGUSR2 to the users!