### PR TITLE
Support float literals without integer-part

### DIFF
--- a/src/modules/Parser/pike_tokenizer.h
+++ b/src/modules/Parser/pike_tokenizer.h
@@ -17,6 +17,15 @@ static unsigned int TOKENIZE(struct array **res, CHAR *data, unsigned int len)
 	    pos++;
 	  break;
 	}
+        else if ( data[pos+1] >= '0' && data[pos+1] <= '9' )
+        {
+          pos++;
+          while(pos < len && data[pos] >= '0' && data[pos] <= '9')
+            pos++;
+          if (pos != len)
+            pos--;
+        }
+
 	break;
 
       case '0':


### PR DESCRIPTION
Float literals like `.001` was previously tokenized as `({ ".", "001" })`. These will now be treated as a single token.
