### PR TITLE
Pop args in getxattr()

### DIFF
--- a/src/modules/_Stdio/efuns.c
+++ b/src/modules/_Stdio/efuns.c
@@ -259,6 +259,8 @@ static void f_getxattr(INT32 args)
     } while( (res < 0) && (errno == ERANGE) );
   }
 
+  pop_n_elems(args);
+
   if( res < 0 )
   {
     if( do_free && ptr )

--- a/src/modules/_Stdio/file.cmod
+++ b/src/modules/_Stdio/file.cmod
@@ -4084,6 +4084,8 @@ static void file_getxattr(INT32 args)
     while( (res < 0) && (errno == ERANGE) );
   }
 
+  pop_n_elems(args);
+
   if( res < 0 )
   {
     if( do_free && ptr )


### PR DESCRIPTION
This fixes a memory corruption bug when using getxattr().

`"#" + getxattr("/", "invalid");` would result in "invalid0" instead of the expected "#0".
In the case of a valid xattr the 0 would've simply been the value, but the "#" would've been replaced with the xattr name still.

Stdio.File()->getxattr() doesn't appear to behave the same way, but it seems to me like pop_n_elems(args) should be in there as well.