### PR TITLE
Correct some typos in error strings

### DIFF
--- a/src/builtin_functions.c
+++ b/src/builtin_functions.c
@@ -1266,7 +1266,7 @@ PMOD_EXPORT void f_has_prefix(INT32 args)
       /* Note: Integers do not need to be freed. */
       object_index_no_free(Pike_sp-1, o, inherit_no, Pike_sp-1);
       if (TYPEOF(Pike_sp[-1]) != PIKE_T_INT) {
-	Pike_error("Unexepected value returned from index operator.\n");
+	Pike_error("Unexpected value returned from index operator.\n");
       }
       if (ch != Pike_sp[-1].u.integer) {
 	pop_n_elems(args + 1);
@@ -7581,7 +7581,7 @@ static inline int diff_ponder_array(int x,
  *
  * For binary data:
  *  K == 256 => O(Na * Nb * lg(Na * Nb)),
- *  Na ~= Nb ~= N => O(N² * lg(N))
+ *  Na ~= Nb ~= N => O(NÂ² * lg(N))
  *
  * For ascii data:
  *  K ~= C * min(Na, Nb), C constant => O(max(Na, Nb)*lg(max(Na,Nb))),

--- a/src/docode.c
+++ b/src/docode.c
@@ -3023,7 +3023,7 @@ static int do_docode2(node *n, int flags)
 
   case F_ARROW:
     if(CDR(n)->token != F_CONSTANT || TYPEOF(CDR(n)->u.sval) != T_STRING)
-      Pike_fatal("Bugg in F_ARROW, index not string.\n");
+      Pike_fatal("Bug in F_ARROW, index not string.\n");
     if(flags & WANT_LVALUE)
     {
       /* FIXME!!!! ??? I wonder what needs fixing... /Hubbe */

--- a/src/encode.c
+++ b/src/encode.c
@@ -2486,7 +2486,7 @@ static struct object *decoder_codec (struct decode_data *data)
   struct pike_string *decoder_str;
   if (data->codec) return data->codec;
   if (data->explicit_codec)
-    Pike_fatal("Trying to load codec while explicitely opted out.\n");
+    Pike_fatal("Trying to load codec while explicitly opted out.\n");
   MAKE_CONST_STRING (decoder_str, "Decoder");
   return data->codec = lookup_codec (decoder_str);
 }

--- a/src/language.yacc
+++ b/src/language.yacc
@@ -1054,7 +1054,7 @@ static_assertion: TOK_STATIC_ASSERT '(' assignment_expr ',' assignment_expr ')'
 optional_dot_dot_dot: TOK_DOT_DOT_DOT { $$=1; }
   | TOK_DOT_DOT
   {
-    yyerror("Range indicator ('..') where elipsis ('...') expected.");
+    yyerror("Range indicator ('..') where ellipsis ('...') expected.");
     $$=1;
   }
   | /* empty */ { $$=0; }
@@ -1598,7 +1598,7 @@ number_or_minint: /* Empty */
 expected_dot_dot: TOK_DOT_DOT
   | TOK_DOT_DOT_DOT
   {
-    yyerror("Elipsis ('...') where range indicator ('..') expected.");
+    yyerror("Ellipsis ('...') where range indicator ('..') expected.");
   }
   ;
 

--- a/src/operators.c
+++ b/src/operators.c
@@ -2661,7 +2661,7 @@ PMOD_EXPORT void o_and(void)
   {
   case T_OBJECT:
     if(!call_lfun(LFUN_AND,LFUN_RAND))
-      PIKE_ERROR("`&", "Bitwise and on objects without `& operator.\n", Pike_sp, 2);
+      PIKE_ERROR("`&", "Bitwise AND on objects without `& operator.\n", Pike_sp, 2);
     return;
 
   case T_INT:
@@ -2979,7 +2979,7 @@ PMOD_EXPORT void o_or(void)
   {
   case T_OBJECT:
     if(!call_lfun(LFUN_OR,LFUN_ROR))
-      PIKE_ERROR("`|", "Bitwise or on objects without `| operator.\n", Pike_sp, 2);
+      PIKE_ERROR("`|", "Bitwise OR on objects without `| operator.\n", Pike_sp, 2);
     return;
 
   case T_INT:
@@ -3238,7 +3238,7 @@ PMOD_EXPORT void o_xor(void)
   {
   case T_OBJECT:
     if(!call_lfun(LFUN_XOR,LFUN_RXOR))
-      PIKE_ERROR("`^", "Bitwise xor on objects without `^ operator.\n", Pike_sp, 2);
+      PIKE_ERROR("`^", "Bitwise XOR on objects without `^ operator.\n", Pike_sp, 2);
     return;
 
   case T_INT:

--- a/src/program.c
+++ b/src/program.c
@@ -6688,7 +6688,7 @@ void compiler_do_inherit(node *n,
 	  offset++;
 	}
 	if (!state) {
-	  yyerror("Failed to resolv external constant.");
+	  yyerror("Failed to resolve external constant.");
 	  return;
 	}
 	p = state->new_program;
@@ -8851,7 +8851,7 @@ int store_prog_string(struct pike_string *str)
   return Pike_compiler->new_program->num_strings-1;
 }
 
-/* NOTE: O(n²)! */
+/* NOTE: O(nÂ²)! */
 int store_constant(const struct svalue *foo,
 		   int equal,
 		   struct pike_string *UNUSED(constant_name))

--- a/src/sscanf.c
+++ b/src/sscanf.c
@@ -1276,7 +1276,7 @@ INPUT_IS_WIDE(								 \
 	          goto test_again;					 \
 									 \
 		case 's':						 \
-		  Pike_error("Illegal to have two adjecent %%s.\n");	 \
+		  Pike_error("Illegal to have two adjacent %%s.\n");	 \
                   UNREACHABLE();                                         \
 									 \
 	  /* sscanf("foo-bar","%s%d",a,b) might not work as expected */	 \
@@ -1709,7 +1709,7 @@ INT32 low_sscanf(struct pike_string *data, struct pike_string *format,
  *!     endianness. For example @expr{"%-2c"@} decodes @expr{"0101"@}
  *!     into @expr{12592@}, leaving @expr{"01"@} for later directives.
  *!     The sign modifiers can be used to modify the signature of the
- *!     data, making @expr{"%+1c"@} decode @expr{"ä"@} into
+ *!     data, making @expr{"%+1c"@} decode @expr{"Ã¤"@} into
  *!     @expr{-28@}.
  *!   @value "%n"
  *!     Returns the current character offset in @[data].


### PR DESCRIPTION
Hi,

Spell-check some error messages emitted by pike compiler. Two files were automatically converted to utf8 in this patch (i.e. the updated comment lines).

TYPO:
-----
1. elipsis -> ellipsis
2. bugg -> bug
3. resolv -> resolve
4. adjecent -> adjacent
5. explicitely -> explicitly
6. unexepected -> unexpected

CLARITY:
------
* Avoid using lowercase "Bitwise and/or/xor" (text "or on" is difficult to read)

This patch survives a build on Linux/aarch64. I triggered one of the error conditions manually:
```
%pike91 
Pike v9.1 release 2 running Hilfe v3.5 (Incremental Pike Frontend)
> string s = "111111111111111111111111111111111";
> s[1...3];
Compiler Error: 1: Ellipsis ('...') where range indicator ('..') expected.
Terminal closed.
```