### PR TITLE
clean up unused xmalloc()

### DIFF
--- a/src/dmalloc.h
+++ b/src/dmalloc.h
@@ -9,7 +9,6 @@
 
 PMOD_EXPORT extern void *debug_xalloc(size_t);
 PMOD_EXPORT extern void debug_xfree(void *);
-PMOD_EXPORT extern void *debug_xmalloc(size_t);
 PMOD_EXPORT extern void *debug_xcalloc(size_t,size_t);
 PMOD_EXPORT extern void *debug_xrealloc(void *,size_t);
 PMOD_EXPORT char *debug_xstrdup(const char *src);
@@ -140,7 +139,6 @@ const char *dmalloc_find_name(void *p);
 
 #define xalloc(X) ((void *)debug_malloc_update_location((void *)debug_xalloc(X), DMALLOC_NAMED_LOCATION(" xalloc")))
 #define xcalloc(N, S) ((void *)debug_malloc_update_location((void *)debug_xcalloc(N, S), DMALLOC_NAMED_LOCATION(" xcalloc")))
-#define xmalloc(X) ((void *)debug_malloc_update_location((void *)debug_xmalloc(X), DMALLOC_NAMED_LOCATION(" xmalloc")))
 #define xrealloc(N, S) ((void *)debug_malloc_update_location((void *)debug_xrealloc(N, S), DMALLOC_NAMED_LOCATION(" xrealloc")))
 #define xstrdup(X) ((void *)debug_malloc_update_location((void *)debug_xstrdup(X), DMALLOC_NAMED_LOCATION(" xstrdup")))
 #define xfree(X) debug_xfree(debug_malloc_update_location((X), DMALLOC_NAMED_LOCATION(" free")))
@@ -230,10 +228,8 @@ PMOD_EXPORT struct mallinfo dlmallinfo(void);
 #define xstrdup debug_xstrdup
 
 #if defined(DYNAMIC_MODULE) && defined(__NT__) && !defined(USE_DLL)
-#define xmalloc debug_xmalloc
 #define xfree debug_xfree
 #else
-#define xmalloc malloc
 #define xfree free
 #endif /* defined(DYNAMIC_MODULE) && defined(__NT__) && !defined(USE_DLL) */
 

--- a/src/pike_memory.c
+++ b/src/pike_memory.c
@@ -511,11 +511,6 @@ PMOD_EXPORT void debug_xfree(void *mem)
   free(mem);
 }
 
-PMOD_EXPORT void *debug_xmalloc(size_t s)
-{
-  return malloc(s);
-}
-
 PMOD_EXPORT void *debug_xrealloc(void *m, size_t s)
 {
   void *ret = realloc(m,s);

--- a/src/pike_memory.h
+++ b/src/pike_memory.h
@@ -238,7 +238,6 @@ PMOD_EXPORT size_t hashmem(const void *, size_t len, size_t mlen) ATTRIBUTE((pur
 #define MALLOC_FUNCTION  ATTRIBUTE((malloc)) PIKE_WARN_UNUSED_RESULT_ATTRIBUTE
 
 PMOD_EXPORT void *debug_xalloc(size_t size) MALLOC_FUNCTION;
-PMOD_EXPORT void *debug_xmalloc(size_t s) MALLOC_FUNCTION;
 PMOD_EXPORT void debug_xfree(void *mem);
 PMOD_EXPORT void *debug_xrealloc(void *m, size_t s) MALLOC_FUNCTION;
 PMOD_EXPORT void *debug_xcalloc(size_t n, size_t s) MALLOC_FUNCTION;


### PR DESCRIPTION
* I observed  that it's possible to build Pike without the definition of debug_xmalloc()
* Most things seem to use xalloc()/debug_xalloc() as a wrapper for malloc()
* Is there any reason to keep xmalloc()?
