### PR TITLE
fail early for invalid usage -D''

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -393,6 +393,11 @@ int main(int argc, char **argv)
 	switch(*p)
 	{
 	case 'D':
+	  if(*(p+1) == '\0')
+	    {
+	      fprintf(stderr,"Missing macro name after '-D'\n");
+	      exit(1);
+	    }
 	  add_predefine(p+1);
 	  p+=strlen(p);
 	  break;


### PR DESCRIPTION
* The argument to -D cannot be separated by a space,
* Avoid calling add_predefine() if a name is not passed to -D
* add_predefine() creates a bad entry in predef list in this case

```
%# breakpoint confirms add_predefine() is passed an empty string
%gdb /usr/local/pike/9.1.2/bin/pike 
GNU gdb (Debian 13.1-3) 13.1
<SNIP>
(gdb) b add_predefine
Breakpoint 1 at 0x983d4: file /home/x/Pike/src/cpp.cmod, line 6134.
(gdb) run -D script.pike
Starting program: /usr/local/pike/9.1.2/bin/pike -D script.pike
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".

Breakpoint 1, add_predefine (s=s@entry=0x7ffffff28f "") at /home/x/Pike/src/cpp.cmod:6134
6134	  struct pike_predef_s *tmp=ALLOC_STRUCT(pike_predef_s);
(gdb) n
6135	  size_t len = strlen(s);
(gdb) 
6136	  char *pos=strchr(s,'=');
(gdb) 
6138	  if(pos)
(gdb) 
6146	    tmp->name = xalloc(len + 1 + 4);
(gdb) 
6147	    memcpy(tmp->name,s,len + 1);
(gdb) 
6149	    tmp->value = tmp->name + len + 1;
(gdb) 
6150	    memcpy(tmp->value," 1 ",4);
(gdb) 
6152	  tmp->next = NULL;
<SNIP>

%# the old version fails later, after predef list is corrupted
%/usr/local/pike/9.1.2/bin/pike -D '' script.pike
There's no master to handle the error. Dumping it raw:
({ /* 2 elements */
    "Expected nonempty string as predefine name, got \"\".\n",
    ({ /* 2 elements */
        backtrace_frame(-:1, init_pike_cpp(), No args),
        backtrace_frame(-:1, define_multiple_macros(), Args: 1)
    })
})

%# now the error looks consistent with "Missing argument to -m".
%./pike -D'' script.pike
Missing macro name after '-D'
```