### PR TITLE
Correct some typos (2)

### DIFF
--- a/lib/master.pike.in
+++ b/lib/master.pike.in
@@ -4366,7 +4366,7 @@ void _main(array(string(0..255)) orig_argv)
         exit(0);
 
       case "version":
-        exit(0, version() + " Copyright © 1994-2024 Linköping University\n"
+        exit(0, version() + " Copyright Â© 1994-2024 LinkÃ¶ping University\n"
             "Pike comes with ABSOLUTELY NO WARRANTY; This is free software and you are\n"
             "welcome to redistribute it under certain conditions; read the files\n"
             "COPYING and COPYRIGHT in the Pike distribution for more details.\n");
@@ -4512,7 +4512,7 @@ void _main(array(string(0..255)) orig_argv)
   if(sizeof(argv)==1)
   {
     if(run_tool) {
-      werror("Pike -x specificed without tool name.\n"
+      werror("Pike -x specified without tool name.\n"
 	     "Available tools:\n");
       mapping t = ([]);
       int i;

--- a/man/pike.1
+++ b/man/pike.1
@@ -312,12 +312,12 @@ The maximum number of elements in arrays to describe in backtraces.
 Note that the above environment variables have effect before the default
 master program attempts to load the
 .BR Getopt (3P)
-module, which occurrs before the master program arguments are parsed.
+module, which occurs before the master program arguments are parsed.
 .SH EXIT STATUS
 The following exit values are returned:
 .TP
 .B 0
-Successfull completion.
+Successful completion.
 .TP
 .B >0
 An error occurred. See output on stderr (fd #2) for reason.

--- a/src/encode.c
+++ b/src/encode.c
@@ -1270,7 +1270,7 @@ static void encode_value2(struct svalue *val, struct encode_data *data, int forc
       if (data->canonic)
 	Pike_error("Canonical encoding of programs not supported.\n");
       if (!(val->u.program->flags & PROGRAM_FIXED))
-	Pike_error("Encoding of unfixated programs not supported.\n");
+	Pike_error("Encoding of volatile programs not supported.\n");
       check_stack(1);
       push_svalue(val);
       apply(encoder_codec (data),"nameof", 1);


### PR DESCRIPTION
Hello,

Here are some changes that I missed in Pull-Request 57...

* 2 typos in pike.1 manual
* 1 typo in error string
* 1 wording suggestion in error string (unfixated doesn't make sense)
* 1 line auto-converted to utf8 by git (copyright message)
