### PR TITLE
object.c: remove unused FRAME macros

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -251,23 +251,11 @@ PMOD_EXPORT struct object *low_clone(struct program *p)
 #define CHECK_FRAME()	0
 #endif
 
-#define POP_FRAME()				\
-  CHECK_FRAME();				\
-  Pike_fp=pike_frame->next;			\
-  pike_frame->next=0;				\
-  free_pike_frame(pike_frame); }while(0)
-
 #define POP_FRAME2()				\
   do{CHECK_FRAME();				\
   Pike_fp=pike_frame->next;			\
   pike_frame->next=0;				\
   free_pike_frame(pike_frame);}while(0)
-
-#define LOW_POP_FRAME()				\
-  add_ref(Pike_fp->current_object); \
-  add_ref(Pike_fp->current_program); \
-  POP_FRAME();
-
 
 /**
  * Call object initializers written in C.


### PR DESCRIPTION
* Local macro LOW_POP_FRAME() is unused
* POP_FRAME() was only referenced by LOW_POP_FRAME()
* POP_FRAME2() appears to have the same logic as POP_FRAME()
* This patch survives a build on Linux/aarch64
* The macro POP_FRAME2() could be renamed to POP_FRAME(), but this patch avoids updating the callers