### PR TITLE
Remove some duplicate includes

### DIFF
--- a/src/cpp.cmod
+++ b/src/cpp.cmod
@@ -26,7 +26,6 @@
 #include "cpp.h"
 #include "lex.h"
 #include "sprintf.h"
-#include "pike_compiler.h"
 
 #include <ctype.h>
 

--- a/src/fdlib.c
+++ b/src/fdlib.c
@@ -3492,10 +3492,6 @@ PMOD_EXPORT INT64 pike_writev(int fd, struct iovec *iov, int iovcnt)
   return sent;
 }
 
-#ifdef HAVE_SYS_UIO_H
-#include <sys/uio.h>
-#endif /* HAVE_SYS_UIO_H */
-
 #ifdef HAVE_NETINET_TCP_H
 #include <netinet/tcp.h>
 #endif /* HAVE_NETINET_TCP_H */


### PR DESCRIPTION
I started with the command...
```
for f in `find . -name '*.c'`; do echo "FILE=$f"; fgrep '#include' $f | sort | uniq -d; done
```
Some results appear to be false positives because the .h files are written as templates; these are intended for inclusion multiple times:
ntlibfuncs.h
fsort_template.h
combine_path.h
program_areas.h
errors.h
lexer.h
compilation.h

Some other results were guarded by ifdef conditions. In cpp.cmod, pike_compiler.h appears in include list twice. In fdlib.c, sys/uio.h is included (if available) at the top of the file.
